### PR TITLE
fix small documentation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ sslmgmt::certs:
 
 ```puppet
 sslmgmt::cert{ 'cert_base_file_title':
-  pkistore: 'default',
+  pkistore => 'default',
 }
 ```
 


### PR DESCRIPTION
I believe this should be the hashrocket instead of the colon.
