### PR TITLE
allow newer versions of stdlib

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": "4.4.x"
+      "version_requirement": ">= 4.4.0 < 4.8.0" 
     }
   ],
   "tags": [


### PR DESCRIPTION
I've manually tested this with my setup for creating keys and haven't hit any issues.  There are several modules that require newer versions of stdlib and having it set to 4.4.0 causes conflicts with tools like r10k and librarian-puppet
