### PR TITLE
bump metadata.json to allow for newer versions of stdlib

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.4.0 <= 4.9.0" 
+      "version_requirement": ">= 4.4.0 <= 5.0.0" 
     }
   ],
   "tags": [

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "tykeal-sslmgmt",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "tykeal",
   "summary": "A simple way to manage certificates in your infrastructure without an HSM.",
   "license": "Apache-2.0",
@@ -16,7 +16,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.4.0 < 4.8.0" 
+      "version_requirement": ">= 4.4.0 <= 4.9.0" 
     }
   ],
   "tags": [


### PR DESCRIPTION
A lot of other modules use newer versions of stdlib, which causes a conflict.

Just a simple bump in version number in the metadata.json.
